### PR TITLE
Feat/s3uploader

### DIFF
--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
 
     // aws
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.547'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.643'
 }
 
 

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     // kafka 의존성
     implementation 'org.springframework.kafka:spring-kafka'
+
+    // aws
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.547'
 }
 
 

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/common/util/S3Config.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/common/util/S3Config.java
@@ -1,0 +1,34 @@
+package ready_to_marry.catalogservice.common.util;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/common/util/S3Uploader.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/common/util/S3Uploader.java
@@ -1,0 +1,58 @@
+package ready_to_marry.catalogservice.common.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+    private final String bucketName = "rtm-app-bucket"; // 또는 @Value 로 주입
+
+    /**
+     * 1. 폴더 기준 업로드 (파일명 자동 생성)
+     * ex) uploadToFolder(file, "admin/events")
+     */
+    public String uploadToFolder(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + System.currentTimeMillis() + "-" + file.getOriginalFilename();
+        return putAndReturnUrl(file, fileName);
+    }
+
+    /**
+     * 2. Key 직접 지정 업로드
+     * ex) uploadWithKey(file, "admin/events/event-123.jpg")
+     */
+    public String uploadWithKey(MultipartFile file, String key) {
+        return putAndReturnUrl(file, key);
+    }
+
+    /**
+     * 3. 파일 삭제
+     */
+    public void delete(String key) {
+        amazonS3.deleteObject(bucketName, key);
+    }
+
+    /**
+     * 내부 공통 업로드 로직
+     */
+    private String putAndReturnUrl(MultipartFile file, String key) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(file.getSize());
+            metadata.setContentType(file.getContentType());
+
+            amazonS3.putObject(bucketName, key, file.getInputStream(), metadata);
+
+            return amazonS3.getUrl(bucketName, key).toString();
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+    }
+}

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/item/controller/PartnerItemController.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/item/controller/PartnerItemController.java
@@ -3,12 +3,15 @@ package ready_to_marry.catalogservice.item.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import ready_to_marry.catalogservice.common.dto.ApiResponse;
 import ready_to_marry.catalogservice.item.dto.request.ItemRegisterRequest;
 import ready_to_marry.catalogservice.item.dto.request.ItemUpdateRequest;
 import ready_to_marry.catalogservice.item.dto.response.ItemListResponse;
+import ready_to_marry.catalogservice.item.dto.response.ItemDetailResponse;
 import ready_to_marry.catalogservice.item.service.ItemService;
 
 import java.util.List;
@@ -20,19 +23,24 @@ public class PartnerItemController {
 
     private final ItemService service;
 
-    // 1. 등록 -> Partner
-    @PostMapping
+    // 1. 등록 -> Partner (with image upload)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> register(
             @RequestHeader("X-Partner-Id") Long partnerId,
-            @RequestBody @Valid ItemRegisterRequest request) {
-        Long itemId = service.register(partnerId, request);
+            @RequestPart("request") @Valid ItemRegisterRequest request,
+            @RequestPart("thumbnail") MultipartFile thumbnail,
+            @RequestPart("descriptionImage") MultipartFile descriptionImage) {
+        Long itemId = service.register(partnerId, request, thumbnail, descriptionImage);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(itemId));
     }
 
-    // 2. 수정 -> Partner
-    @PatchMapping("/{itemId}")
-    public ApiResponse<?> update(@PathVariable Long itemId, @RequestBody @Valid ItemUpdateRequest request) {
-        service.update(itemId, request);
+    // 2. 수정 -> Partner (with image upload)
+    @PatchMapping(value = "/{itemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<?> update(@PathVariable Long itemId,
+                                 @RequestPart("request") @Valid ItemUpdateRequest request,
+                                 @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
+                                 @RequestPart(value = "descriptionImage", required = false) MultipartFile descriptionImage) {
+        service.update(itemId, request, thumbnail, descriptionImage);
         return ApiResponse.success(null);
     }
 
@@ -42,7 +50,6 @@ public class PartnerItemController {
         service.delete(itemIds);
         return ApiResponse.success(null);
     }
-
 
     // 4. Partner -> Header에서 partnerId로 item 목록 조회
     @GetMapping
@@ -55,4 +62,9 @@ public class PartnerItemController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 5. 단건 조회
+    @GetMapping("/{itemId}")
+    public ApiResponse<ItemDetailResponse> getDetail(@PathVariable Long itemId) {
+        return ApiResponse.success(service.getItemDetails(itemId));
+    }
 }

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/item/dto/request/ItemRegisterRequest.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/item/dto/request/ItemRegisterRequest.java
@@ -25,8 +25,9 @@ public class ItemRegisterRequest {
     @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private Long price;
 
-    @NotBlank(message = "썸네일 이미지 URL은 필수입니다.")
+    // 이미지 URL → 이미지 파일로 대체 (S3 업로드로 설정됨)
     private String thumbnailUrl;
+    private String descriptionImageUrl;
 
     @NotNull(message = "태그 목록은 필수입니다.")
     @Size(min = 1, message = "태그는 최소 1개 이상이어야 합니다.")
@@ -42,9 +43,6 @@ public class ItemRegisterRequest {
     @NotBlank(message = "상세 설명은 필수입니다.")
     private String description;
 
-    @NotBlank(message = "설명 이미지 URL은 필수입니다.")
-    private String descriptionImageUrl;
-
     // 웨딩홀 전용
     private Integer mealPrice;
     private Integer capacity;
@@ -53,7 +51,6 @@ public class ItemRegisterRequest {
     // 영상/청첩장 전용
     private Integer duration;
 
-    // 조건부 유효성: 웨딩홀일 때 웨딩홀 필드 필수
     @AssertTrue(message = "웨딩홀 등록 시 식대, 수용 인원, 주차 공간은 필수입니다.")
     public boolean isValidForWeddingHall() {
         if (field == FieldType.WEDDING_HALL) {
@@ -62,7 +59,6 @@ public class ItemRegisterRequest {
         return true;
     }
 
-    // 조건부 유효성: 영상/청첩장일 때 duration 필수
     @AssertTrue(message = "영상/청첩장 등록 시 예상 배송 기간은 필수입니다.")
     public boolean isValidForVideoOrInvitation() {
         if (field == FieldType.VIDEO || field == FieldType.INVITATION) {

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/item/dto/request/ItemUpdateRequest.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/item/dto/request/ItemUpdateRequest.java
@@ -15,12 +15,12 @@ public class ItemUpdateRequest {
     @NotBlank(message = "지역 정보는 필수입니다.")
     private String region;
 
-    // 가격 문의 허용
     @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private Long price;
 
-    @NotBlank(message = "썸네일 이미지 URL은 필수입니다.")
+    // 이미지 URL → 이미지 파일로 대체 (S3 업로드로 설정됨)
     private String thumbnailUrl;
+    private String descriptionImageUrl;
 
     @NotNull(message = "태그 목록은 필수입니다.")
     @Size(min = 1, message = "태그는 최소 1개 이상이어야 합니다.")
@@ -36,10 +36,6 @@ public class ItemUpdateRequest {
     @NotBlank(message = "상세 설명은 필수입니다.")
     private String description;
 
-    @NotBlank(message = "설명 이미지 URL은 필수입니다.")
-    private String descriptionImageUrl;
-
-    // 카테고리 기반 조건부 필수 필드
     private Integer mealPrice;
     private Integer capacity;
     private Integer parkingCapacity;
@@ -48,7 +44,6 @@ public class ItemUpdateRequest {
     @NotNull(message = "세부 필드는 필수입니다.")
     private FieldType field;
 
-    // ✅ 웨딩홀 조건부 검증
     @AssertTrue(message = "웨딩홀 수정 시 식대, 수용 인원, 주차 공간은 필수입니다.")
     public boolean isValidForWeddingHall() {
         if (field == FieldType.WEDDING_HALL) {
@@ -57,7 +52,6 @@ public class ItemUpdateRequest {
         return true;
     }
 
-    // ✅ 영상/청첩장 조건부 검증
     @AssertTrue(message = "영상/청첩장 등록 시 예상 배송 기간은 필수입니다.")
     public boolean isValidForVideoOrInvitation() {
         if (field == FieldType.VIDEO || field == FieldType.INVITATION) {
@@ -66,3 +60,4 @@ public class ItemUpdateRequest {
         return true;
     }
 }
+

--- a/CatalogService/src/main/java/ready_to_marry/catalogservice/item/service/ItemService.java
+++ b/CatalogService/src/main/java/ready_to_marry/catalogservice/item/service/ItemService.java
@@ -3,9 +3,11 @@ package ready_to_marry.catalogservice.item.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import ready_to_marry.catalogservice.common.exception.ErrorCode;
 import ready_to_marry.catalogservice.common.exception.InfrastructureException;
 import ready_to_marry.catalogservice.common.exception.NotFoundException;
+import ready_to_marry.catalogservice.common.util.S3Uploader;
 import ready_to_marry.catalogservice.detail.entity.*;
 import ready_to_marry.catalogservice.detail.repository.*;
 import ready_to_marry.catalogservice.detail.service.DetailService;
@@ -37,6 +39,191 @@ public class ItemService {
     private final InvitationRepository invitationRepository;
     private final VideoRepository videoRepository;
     private final ItemKafkaProducer itemKafkaProducer;
+    private final S3Uploader s3Uploader;
+
+    public Long register(Long partnerId, ItemRegisterRequest request, MultipartFile thumbnail, MultipartFile descriptionImage) {
+        try {
+            Item item = Item.builder()
+                    .partnerId(partnerId)
+                    .category(request.getCategory())
+                    .field(request.getField())
+                    .name(request.getName())
+                    .region(request.getRegion())
+                    .price(request.getPrice())
+                    .build();
+            itemRepository.save(item);
+
+            Long itemId = item.getItemId();
+            String thumbnailKey = String.format("items/thumbnails/item-%d.jpg", itemId);
+            String descriptionKey = String.format("items/details/item-%d-desc.jpg", itemId);
+            String thumbnailUrl = s3Uploader.uploadWithKey(thumbnail, thumbnailKey);
+            String descriptionUrl = s3Uploader.uploadWithKey(descriptionImage, descriptionKey);
+            item.setThumbnailUrl(thumbnailUrl);
+
+            styleRepository.saveAll(request.getStyles().stream().map(style -> new Style(null, itemId, style)).toList());
+            tagRepository.saveAll(request.getTags().stream().map(tag -> new Tag(null, itemId, tag)).toList());
+
+            switch (request.getField()) {
+                case WEDDING_HALL -> weddingHallRepository.save(WeddingHall.builder().item(item).address(request.getAddress()).mealPrice(request.getMealPrice()).capacity(request.getCapacity()).parkingCapacity(request.getParkingCapacity()).descriptionImageUrl(descriptionUrl).build());
+                case STUDIO -> studioRepository.save(Studio.builder().item(item).address(request.getAddress()).description(request.getDescription()).descriptionImageUrl(descriptionUrl).build());
+                case DRESS -> dressRepository.save(Dress.builder().item(item).address(request.getAddress()).description(request.getDescription()).descriptionImageUrl(descriptionUrl).build());
+                case MAKEUP -> makeupRepository.save(Makeup.builder().item(item).address(request.getAddress()).description(request.getDescription()).descriptionImageUrl(descriptionUrl).build());
+                case BOUQUET -> bouquetRepository.save(Bouquet.builder().item(item).address(request.getAddress()).description(request.getDescription()).descriptionImageUrl(descriptionUrl).build());
+                case INVITATION -> invitationRepository.save(Invitation.builder().item(item).description(request.getDescription()).descriptionImageUrl(descriptionUrl).duration(request.getDuration()).build());
+                case VIDEO -> videoRepository.save(Video.builder().item(item).address(request.getAddress()).description(request.getDescription()).descriptionImageUrl(descriptionUrl).build());
+                default -> throw new IllegalArgumentException("Unknown category: " + request.getCategory());
+            }
+
+            itemKafkaProducer.sendItem("items", ItemKafkaDTO.builder()
+                    .operation("create")
+                    .itemId(itemId)
+                    .partnerId(partnerId)
+                    .category(item.getCategory().name())
+                    .field(item.getField().name())
+                    .name(item.getName())
+                    .created_at(item.getCreatedAt().toString())
+                    .region(item.getRegion())
+                    .price(item.getPrice())
+                    .thumbnail_url(thumbnailUrl)
+                    .tags(request.getTags())
+                    .styles(request.getStyles())
+                    .build());
+
+            return itemId;
+        } catch (Exception e) {
+            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
+        }
+    }
+
+    public void update(Long itemId, ItemUpdateRequest request, MultipartFile thumbnail, MultipartFile descriptionImage) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
+
+        try {
+            item.setName(request.getName());
+            item.setPrice(request.getPrice());
+            item.setRegion(request.getRegion());
+
+            if (thumbnail != null && !thumbnail.isEmpty()) {
+                String thumbnailKey = String.format("items/thumbnails/item-%d.jpg", itemId);
+                String thumbnailUrl = s3Uploader.uploadWithKey(thumbnail, thumbnailKey);
+                item.setThumbnailUrl(thumbnailUrl);
+            }
+
+            tagRepository.deleteByItemId(itemId);
+            styleRepository.deleteByItemId(itemId);
+
+            tagRepository.saveAll(request.getTags().stream().map(tag -> new Tag(null, itemId, tag)).toList());
+            styleRepository.saveAll(request.getStyles().stream().map(style -> new Style(null, itemId, style)).toList());
+
+            switch (item.getField()) {
+                case WEDDING_HALL -> weddingHallRepository.findById(itemId).ifPresent(hall -> {
+                    hall.setAddress(request.getAddress());
+                    hall.setMealPrice(request.getMealPrice());
+                    hall.setCapacity(request.getCapacity());
+                    hall.setParkingCapacity(request.getParkingCapacity());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        hall.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case STUDIO -> studioRepository.findById(itemId).ifPresent(studio -> {
+                    studio.setAddress(request.getAddress());
+                    studio.setDescription(request.getDescription());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        studio.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case DRESS -> dressRepository.findById(itemId).ifPresent(dress -> {
+                    dress.setAddress(request.getAddress());
+                    dress.setDescription(request.getDescription());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        dress.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case MAKEUP -> makeupRepository.findById(itemId).ifPresent(makeup -> {
+                    makeup.setAddress(request.getAddress());
+                    makeup.setDescription(request.getDescription());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        makeup.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case BOUQUET -> bouquetRepository.findById(itemId).ifPresent(bouquet -> {
+                    bouquet.setAddress(request.getAddress());
+                    bouquet.setDescription(request.getDescription());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        bouquet.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case INVITATION -> invitationRepository.findById(itemId).ifPresent(invite -> {
+                    invite.setDescription(request.getDescription());
+                    invite.setDuration(request.getDuration());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        invite.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+                case VIDEO -> videoRepository.findById(itemId).ifPresent(video -> {
+                    video.setAddress(request.getAddress());
+                    video.setDescription(request.getDescription());
+                    if (descriptionImage != null && !descriptionImage.isEmpty()) {
+                        String key = String.format("items/details/item-%d-desc.jpg", itemId);
+                        video.setDescriptionImageUrl(s3Uploader.uploadWithKey(descriptionImage, key));
+                    }
+                });
+            }
+        } catch (Exception e) {
+            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
+        }
+    }
+
+    public void delete(List<Long> itemIds) {
+        try {
+            for (Long itemId : itemIds) {
+                Item item = itemRepository.findById(itemId)
+                        .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
+
+                switch (item.getField()) {
+                    case WEDDING_HALL -> weddingHallRepository.deleteById(itemId);
+                    case STUDIO -> studioRepository.deleteById(itemId);
+                    case DRESS -> dressRepository.deleteById(itemId);
+                    case MAKEUP -> makeupRepository.deleteById(itemId);
+                    case BOUQUET -> bouquetRepository.deleteById(itemId);
+                    case INVITATION -> invitationRepository.deleteById(itemId);
+                    case VIDEO -> videoRepository.deleteById(itemId);
+                }
+            }
+            tagRepository.deleteByItemIdIn(itemIds);
+            styleRepository.deleteByItemIdIn(itemIds);
+            itemRepository.deleteAllById(itemIds);
+            itemKafkaProducer.sendItem("items", ItemKafkaDTO.builder().operation("delete").itemIds(itemIds).build());
+        } catch (Exception e) {
+            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
+        }
+    }
+
+    public ItemDetailResponse getItemDetails(Long itemId) {
+        return this.detailById(itemId);
+    }
+
+    public ItemDetailResponse detailById(Long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
+
+        DetailService service = detailServices.stream()
+                .filter(d -> d.getField().equals(item.getField()))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("No detail handler for: " + item.getField()));
+
+        List<String> tags = tagRepository.findByItemId(itemId).stream().map(Tag::getTag).toList();
+        List<String> styles = styleRepository.findByItemId(itemId).stream().map(Style::getStyle).toList();
+
+        return service.toResponse(item, styles, tags);
+    }
 
     public ItemListResponse listByPartner(Long partnerId, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("itemId").descending());
@@ -57,248 +244,5 @@ public class ItemService {
         }).toList();
 
         return new ItemListResponse(itemPage.getTotalElements(), page, size, items);
-    }
-
-    public ItemDetailResponse detailById(Long itemId) {
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
-
-        DetailService service = detailServices.stream()
-                .filter(d -> d.getField().equals(item.getField()))
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException("No detail handler for: " + item.getField()));
-
-        List<String> tags = tagRepository.findByItemId(itemId).stream().map(Tag::getTag).toList();
-        List<String> styles = styleRepository.findByItemId(itemId).stream().map(Style::getStyle).toList();
-
-        return service.toResponse(item, styles, tags);
-    }
-
-    public Long register(Long partnerId, ItemRegisterRequest request) {
-        try {
-            Item item = Item.builder()
-                    .partnerId(partnerId)
-                    .category(request.getCategory())
-                    .field(request.getField())
-                    .name(request.getName())
-                    .region(request.getRegion())
-                    .price(request.getPrice())
-                    .thumbnailUrl(request.getThumbnailUrl())
-                    .build();
-            itemRepository.save(item);
-
-            List<Style> styles = request.getStyles().stream()
-                    .map(style -> new Style(null, item.getItemId(), style))
-                    .toList();
-            List<Tag> tags = request.getTags().stream()
-                    .map(tag -> new Tag(null, item.getItemId(), tag))
-                    .toList();
-
-            styleRepository.saveAll(styles);
-            tagRepository.saveAll(tags);
-
-            switch (request.getField()) {
-                case WEDDING_HALL -> weddingHallRepository.save(
-                        WeddingHall.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .mealPrice(request.getMealPrice())
-                                .capacity(request.getCapacity())
-                                .parkingCapacity(request.getParkingCapacity())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                case STUDIO -> studioRepository.save(
-                        Studio.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                case DRESS -> dressRepository.save(
-                        Dress.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                case MAKEUP -> makeupRepository.save(
-                        Makeup.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                case BOUQUET -> bouquetRepository.save(
-                        Bouquet.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                case INVITATION -> invitationRepository.save(
-                        Invitation.builder()
-                                .item(item)
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .duration(request.getDuration())
-                                .build()
-                );
-                case VIDEO -> videoRepository.save(
-                        Video.builder()
-                                .item(item)
-                                .address(request.getAddress())
-                                .description(request.getDescription())
-                                .descriptionImageUrl(request.getDescriptionImageUrl())
-                                .build()
-                );
-                default -> throw new IllegalArgumentException("Unknown category: " + request.getCategory());
-            }
-
-            ItemKafkaDTO itemKafkaDto = ItemKafkaDTO.builder()
-                    .operation("create")
-                    .itemId(item.getItemId())
-                    .partnerId(item.getPartnerId())
-                    .category(item.getCategory().name())
-                    .field(item.getField().name())
-                    .name(item.getName())
-                    .created_at(item.getCreatedAt().toString())
-                    .region(item.getRegion())
-                    .price(item.getPrice())
-                    .thumbnail_url(item.getThumbnailUrl())
-                    .tags(request.getTags())
-                    .styles(request.getStyles())
-                    .build();
-
-            itemKafkaProducer.sendItem("items", itemKafkaDto);
-
-            return item.getItemId();
-        } catch (Exception e) {
-            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
-        }
-    }
-
-    public void update(Long itemId, ItemUpdateRequest request) {
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
-
-        try {
-            item.setName(request.getName());
-            item.setPrice(request.getPrice());
-            item.setRegion(request.getRegion());
-            item.setThumbnailUrl(request.getThumbnailUrl());
-            itemRepository.save(item);
-
-            tagRepository.deleteByItemId(itemId);
-            styleRepository.deleteByItemId(itemId);
-
-            List<Tag> tags = request.getTags().stream()
-                    .map(tag -> new Tag(null, itemId, tag))
-                    .toList();
-            List<Style> styles = request.getStyles().stream()
-                    .map(style -> new Style(null, itemId, style))
-                    .toList();
-
-            tagRepository.saveAll(tags);
-            styleRepository.saveAll(styles);
-
-            switch (item.getField()) {
-                case WEDDING_HALL -> weddingHallRepository.findById(itemId).ifPresent(hall -> {
-                    hall.setAddress(request.getAddress());
-                    hall.setMealPrice(request.getMealPrice());
-                    hall.setCapacity(request.getCapacity());
-                    hall.setParkingCapacity(request.getParkingCapacity());
-                    hall.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-                case STUDIO -> studioRepository.findById(itemId).ifPresent(studio -> {
-                    studio.setAddress(request.getAddress());
-                    studio.setDescription(request.getDescription());
-                    studio.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-                case DRESS -> dressRepository.findById(itemId).ifPresent(dress -> {
-                    dress.setAddress(request.getAddress());
-                    dress.setDescription(request.getDescription());
-                    dress.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-                case MAKEUP -> makeupRepository.findById(itemId).ifPresent(makeup -> {
-                    makeup.setAddress(request.getAddress());
-                    makeup.setDescription(request.getDescription());
-                    makeup.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-                case BOUQUET -> bouquetRepository.findById(itemId).ifPresent(bouquet -> {
-                    bouquet.setAddress(request.getAddress());
-                    bouquet.setDescription(request.getDescription());
-                    bouquet.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-                case INVITATION -> invitationRepository.findById(itemId).ifPresent(invite -> {
-                    invite.setDescription(request.getDescription());
-                    invite.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                    invite.setDuration(request.getDuration());
-                });
-                case VIDEO -> videoRepository.findById(itemId).ifPresent(video -> {
-                    video.setAddress(request.getAddress());
-                    video.setDescription(request.getDescription());
-                    video.setDescriptionImageUrl(request.getDescriptionImageUrl());
-                });
-            }
-
-            ItemKafkaDTO itemKafkaDto = ItemKafkaDTO.builder()
-                    .operation("update")
-                    .itemId(item.getItemId())
-                    .partnerId(item.getPartnerId())
-                    .category(item.getCategory().name())
-                    .field(item.getField().name())
-                    .name(item.getName())
-                    .created_at(item.getCreatedAt().toString())
-                    .region(item.getRegion())
-                    .price(item.getPrice())
-                    .thumbnail_url(item.getThumbnailUrl())
-                    .tags(request.getTags())
-                    .styles(request.getStyles())
-                    .build();
-
-            itemKafkaProducer.sendItem("items", itemKafkaDto);
-
-        } catch (Exception e) {
-            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
-        }
-    }
-
-    public void delete(List<Long> itemIds) {
-        try {
-            for (Long itemId : itemIds) {
-                Item item = itemRepository.findById(itemId)
-                        .orElseThrow(() -> new NotFoundException("Item not found: " + itemId));
-
-                switch (item.getField()) {
-                    case WEDDING_HALL -> weddingHallRepository.deleteById(itemId);
-                    case STUDIO -> studioRepository.deleteById(itemId);
-                    case DRESS -> dressRepository.deleteById(itemId);
-                    case MAKEUP -> makeupRepository.deleteById(itemId);
-                    case BOUQUET -> bouquetRepository.deleteById(itemId);
-                    case INVITATION -> invitationRepository.deleteById(itemId);
-                    case VIDEO -> videoRepository.deleteById(itemId);
-                    default -> throw new IllegalArgumentException("Unknown field: " + item.getField());
-                }
-            }
-            tagRepository.deleteByItemIdIn(itemIds);
-            styleRepository.deleteByItemIdIn(itemIds);
-            itemRepository.deleteAllById(itemIds);
-            ItemKafkaDTO deleteDto = ItemKafkaDTO.builder()
-                    .operation("delete")
-                    .itemIds(itemIds)
-                    .build();
-            itemKafkaProducer.sendItem("items", deleteDto);
-        } catch (Exception e) {
-            throw new InfrastructureException(ErrorCode.DB_WRITE_FAILURE, e);
-        }
-    }
-
-    public ItemDetailResponse getItemDetails(Long itemId) {
-        return this.detailById(itemId);
     }
 }


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Partner가 아이템 등록/수정 시 이미지(thumbnail, descriptionImage)를 S3에 업로드하도록 기능 구현
- AWS S3 연동을 위한 `S3Config`, `S3Uploader` 유틸 클래스 추가

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
### 📌 S3 연동 기능

- `S3Config`: `AmazonS3` Client를 Bean으로 등록하는 설정 클래스 추가
- `S3Uploader`:
  - `uploadToFolder(MultipartFile, dir)`: 디렉토리 기반 파일명 자동 업로드
  - `uploadWithKey(MultipartFile, key)`: 고정 key 기반 업로드
  - `delete(String key)`: S3 객체 삭제 지원

### 📌 Partner 아이템 등록/수정 시 이미지 업로드 적용

- `ItemService`의 `register()`, `update()`에 이미지 S3 업로드 로직 반영
  - ID 기반 Key로 고정된 경로로 저장  
    - 썸네일: `items/thumbnails/item-{id}.jpg`  
    - 상세이미지: `items/details/item-{id}-description.jpg`
- 업로드 성공 후 반환된 URL을 각 엔티티 필드에 설정하여 DB 저장
- 기존 `thumbnailUrl`, `descriptionImageUrl` 필드를 요청 DTO에서 제거하고 파일 직접 업로드 방식으로 전환
- `PartnerItemController`: `@RequestPart` 기반 `multipart/form-data` 요청으로 수정
  - `request`, `thumbnail`, `descriptionImage` 분리 처리

## 📸 스크린샷 (Optional)
x

## 🔗 관련 이슈 (Linked Issue)
x

## 📌 참고 사항 (Additional Notes)
x